### PR TITLE
Give hints about failure to converge

### DIFF
--- a/ext/AssignGroupsCSV.jl
+++ b/ext/AssignGroupsCSV.jl
@@ -24,23 +24,6 @@ function Immersion.parse_inputs(parser, file::CSV.Rows)
     return students, Matrix{T}(reshape(preferences, ngroups, nrows)'), String.(collect(keys(first(file)))[4:end])
 end
 
-"""
-    students, preferences = parse_inputs(file::CSV.Rows; preferencescore=-1)
-
-Extract a list of students from a CSV file. The CSV file should have the following format:
-
-    First,Last,Score,Partners
-    StudentA,Last,0.78,
-    StudentB,Last,0.92,"StudentA Last,StudentK Last"
-    StudentC,Last,0.85,
-    ...
-
-The header line is optional.  `Score` is a floating point number, and `Partners` is (optionally) a comma-separated list
-of student names who are requested partners. The `preferencescore` is the score assigned to each requested pairing, i.e.,
-`preferences[i, j] ∈ (0, preferencescore)`.
-
-See also: [`Partners.assign`](@ref).
-"""
 function Partners.parse_inputs(file::CSV.Rows; preferencescore=-1)
     students = Partners.Student[]
     studentidx = Dict{String,Int}()

--- a/test/partners.jl
+++ b/test/partners.jl
@@ -14,7 +14,10 @@ using CSV
         @test mean([s.score for s in g]) ≈ 2
     end
     redirect_stdout(devnull) do
-        @test_logs (:error, r"TIME_LIMIT") (:info, r"Consider") assign(students, 2, zeros(6, 6); time_limit=1e-6)
+        @test_logs (:error, r"TIME_LIMIT") (:info, r"Consider") try
+                assign(students, 2, zeros(6, 6); time_limit=1e-6)  # `value.(A)` fails because there are no solutions in such a short time
+            catch
+            end
     end
 
     groups, status = assign(students, 3, zeros(6, 6))

--- a/test/partners.jl
+++ b/test/partners.jl
@@ -7,12 +7,13 @@ using CSV
 
 @testset "Partners" begin
     students = [Student("Student"*s, "Last", p) for (s, p) in zip('A':'F', [1,2,3,1,2,3])]
-    groups = assign(students, 2, zeros(6, 6))
+    groups, status = assign(students, 2, zeros(6, 6))
+    @test status == OPTIMAL
     for g in groups
         @test length(g) == 3
         @test mean([s.score for s in g]) ≈ 2
     end
-    groups = assign(students, 3, zeros(6, 6))
+    groups, status = assign(students, 3, zeros(6, 6))
     for g in groups
         @test length(g) == 2
         @test mean([s.score for s in g]) ≈ 2
@@ -20,7 +21,7 @@ using CSV
     # A strong preference overrides the score balancing
     prefs = zeros(6, 6)
     prefs[1, 4] = prefs[4, 1] = -1000
-    groups = assign(students, 3, prefs)
+    groups, status = assign(students, 3, prefs)
     any14 = false
     for g in groups
         @test length(g) == 2
@@ -28,7 +29,7 @@ using CSV
     end
     @test any14
     prefs[1, 4] = prefs[4, 1] = -0.1
-    groups = assign(students, 3, prefs)
+    groups, status = assign(students, 3, prefs)
     for g in groups
         @test length(g) == 2
         @test mean([s.score for s in g]) ≈ 2

--- a/test/partners.jl
+++ b/test/partners.jl
@@ -7,12 +7,16 @@ using CSV
 
 @testset "Partners" begin
     students = [Student("Student"*s, "Last", p) for (s, p) in zip('A':'F', [1,2,3,1,2,3])]
-    groups, status = assign(students, 2, zeros(6, 6))
+    groups, status = assign(students, 2, zeros(6, 6); attributes=("mip_rel_gap" => 1e-3,))
     @test status == OPTIMAL
     for g in groups
         @test length(g) == 3
         @test mean([s.score for s in g]) ≈ 2
     end
+    redirect_stdout(devnull) do
+        @test_logs (:error, r"TIME_LIMIT") (:info, r"Consider") assign(students, 2, zeros(6, 6); time_limit=1e-6)
+    end
+
     groups, status = assign(students, 3, zeros(6, 6))
     for g in groups
         @test length(g) == 2


### PR DESCRIPTION
This defaults to a short timeout, and provides hints about how
to adjust settings to control convergence criteria. It also returns
the convergence status, exporting `OPTIMAL` so that users can
test whether the algorithm converged.

This also adds docstrings and moves the `parse_input` docstring to
the function (so that it is always available).